### PR TITLE
Don’t monkey-patch array

### DIFF
--- a/lib/dropbox/extensions/array.rb
+++ b/lib/dropbox/extensions/array.rb
@@ -2,8 +2,4 @@ class Array # :nodoc:
   def extract_options! # :nodoc:
     last.is_a?(::Hash) ? pop : {}
   end unless method_defined?(:extract_options!)
-
-  def to_hash # :nodoc:
-    inject({}) { |hsh, (k,v)| hsh[k] = v  ; hsh }
-  end unless method_defined?(:to_hash)
 end

--- a/spec/dropbox/api_spec.rb
+++ b/spec/dropbox/api_spec.rb
@@ -4,7 +4,7 @@ def url_args(url)
   return {} unless url.include?('?')
   _, back = url.split('?')
   return {} unless back
-  back.split('&').map { |comp| comp.split('=') }.to_hash
+  back.split('&').map { |comp| comp.split('=') }.to_h
 end
 
 def should_receive_api_method_with_arguments(object, method, api_method, arguments, response, path=nil, root=nil)


### PR DESCRIPTION
Aside from generally being a bad idea, this monkey patch appears to only be used in one place and can be substituted for `to_h`.

Specifically, this breaks `Tempfile.new([“basename”, “.txt”])`. You can test this with this code:

```ruby
my_klass = Class.new(DelegateClass(File)) do
  attr_reader :data

  def initialize(basename="", some_keyword: 0)
    @data = {basename: basename, some_keyword: some_keyword}
    super(@data)
  end
end

result = my_klass.new(["foo", "baz"]).data
if result == {:basename=>["foo", "baz"], :some_keyword=>0}
  puts "OK"
else
  puts "OMG IT IS BROKEN! #{result}"
end
```